### PR TITLE
chore(workflows): add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -2,6 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Kubeconform"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ["main"]

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -2,6 +2,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Label Sync"
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Release"
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
- Added `permissions` block to `Release` workflow with `contents: write`.
- Added `permissions` block to `Kubeconform` workflow with `contents: read`.
- Added `permissions` block to `Label Sync` workflow with `contents: read` and `issues: write`.
- Ensures explicit permissions to resolve warnings and align with best practices.